### PR TITLE
Pachinkremental v1.1.1: Minor bugfix

### DIFF
--- a/pachinkremental/README.md
+++ b/pachinkremental/README.md
@@ -40,6 +40,9 @@ I plan to archive the last version before any update that significantly nerfs pr
 
 **Caution: Spoilers below!**
 
+### v1.1.1 (2021-05-03)
+* Fix drop zone being drawn 5 pixels too high in April Fools mode.
+
 ### v1.1.0 (2021-04-30)
 * Add a rotation-based multiplier for beach balls.
 

--- a/pachinkremental/beta/README.md
+++ b/pachinkremental/beta/README.md
@@ -40,6 +40,9 @@ I plan to archive the last version before any update that significantly nerfs pr
 
 **Caution: Spoilers below!**
 
+### v1.1.1 (2021-05-03)
+* Fix drop zone being drawn 5 pixels too high in April Fools mode.
+
 ### v1.1.0-beta (2021-04-26)
 * Add a rotation-based multiplier for beach balls.
 

--- a/pachinkremental/beta/js/canvas.js
+++ b/pachinkremental/beta/js/canvas.js
@@ -685,7 +685,7 @@ function Draw(state) {
 			drop_zone_elem.style.width = width_px + "px";
 			drop_zone_elem.style.height = height_px + "px";
 			if (state.april_fools) {
-				let top_px = state.board.height * state.canvas_scale - height_px
+				let top_px = kTopOffset + state.board.height * state.canvas_scale - height_px
 				let left_px = kLeftOffset + (state.board.width - max_drop_x) * state.canvas_scale;
 				drop_zone_elem.style.top = top_px + "px";
 				drop_zone_elem.style.left = left_px + "px";

--- a/pachinkremental/beta/js/game.js
+++ b/pachinkremental/beta/js/game.js
@@ -1,4 +1,4 @@
-const kVersion = "v1.1.0-beta";
+const kVersion = "v1.1.1-beta";
 const kTitleAndVersion = "Pachinkremental " + kVersion;
 
 var max_drop_y = 20;

--- a/pachinkremental/js/canvas.js
+++ b/pachinkremental/js/canvas.js
@@ -685,7 +685,7 @@ function Draw(state) {
 			drop_zone_elem.style.width = width_px + "px";
 			drop_zone_elem.style.height = height_px + "px";
 			if (state.april_fools) {
-				let top_px = state.board.height * state.canvas_scale - height_px
+				let top_px = kTopOffset + state.board.height * state.canvas_scale - height_px
 				let left_px = kLeftOffset + (state.board.width - max_drop_x) * state.canvas_scale;
 				drop_zone_elem.style.top = top_px + "px";
 				drop_zone_elem.style.left = left_px + "px";

--- a/pachinkremental/js/game.js
+++ b/pachinkremental/js/game.js
@@ -1,4 +1,4 @@
-const kVersion = "v1.1.0";
+const kVersion = "v1.1.1";
 const kTitleAndVersion = "Pachinkremental " + kVersion;
 
 var max_drop_y = 20;


### PR DESCRIPTION
This fixes the drop zone being rendered 5 pixels too high in April Fools mode.