### PR TITLE
More adjustments to still-unused feature

### DIFF
--- a/pachinkremental/beta/js/canvas.js
+++ b/pachinkremental/beta/js/canvas.js
@@ -910,6 +910,7 @@ function DrawHitRates(stats, board, ctx) {
 	ctx.font = "bold " + kFontSize + "px sans-serif";
 	DrawHitRatesForTargetSets(stats, board.target_sets, 2, total_balls, ctx);
 	DrawHitRatesForTargetSets(stats, board.bumper_sets, 4, total_balls, ctx);
+	DrawHitRatesForTargetSets(stats, board.long_bumper_sets, 4, total_balls, ctx);
 	DrawHitRatesForTargetSets(stats, board.portal_sets, 2, total_balls, ctx);
 }
 


### PR DESCRIPTION
* Make LongBumper a subclass of Bumper, and refactor Bumper for better code reuse.
* Add subclasses of LongBumper for exactly vertical and horizontal orientations with physics code optimized for those cases.
* Adjust LongBumper physics to make it much less likely for a ball to clip through them.
* Make targets provide their own axis-aligned hitbox bounding boxes so they only have to be rectangular, not necessarily square.