### PR TITLE
Feature: Add Open Graph protocol tags to enrich link sharing across modern sites

### DIFF
--- a/pachinkremental/pachinkremental.html
+++ b/pachinkremental/pachinkremental.html
@@ -3,6 +3,13 @@
 	<title>Pachinkremental</title>
 
 	<meta charset="UTF-8">
+	<meta property="og:title" content="Pachinkremental" />
+	<meta property="og:description" content="Pachinkremental is a pachinko-based incremental browser game." />
+	<meta property="og:site_name" content="Pachinkremental" />
+	<meta property="og:locale" content="en_US" />
+	<meta property="og:type" content="website" />
+	<meta property="og:url" content="https://poochyexe.github.io/pachinkremental/pachinkremental.html" />
+	<meta property="og:image" content="https://poochyexe.github.io/pachinkremental/favicon/opal.png" />
 
 	<link rel="icon" id="favicon" type="image/png" href="favicon/normal.png">
 	<link rel="stylesheet" type="text/css" href="style.css" />


### PR DESCRIPTION
* Use [OpenGraph protocol ](https://ogp.me/) meta tags to add enriched site info

Helps preview the site when sharing the link and would help with generating engagement and more interest in the game itself. Feel free to modify the contents of the tags if this PR is acceptable.